### PR TITLE
Support `AuthorizationPolicy` resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,4 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+.values.yml

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Simplify the Linkerd Authorization Policies management according to [the article
 | 2.11.x          | 0.1.0 - 0.4.0    |
 | 2.12.x          | \>= 0.5.0        |
 
-New `AuthorizationPolicy` and `HTTPRoute` are in WIP. Their support will be soon.
+New `AuthorizationPolicy` are supported since `0.6.0`.
+
+New `HTTPRoute` are in WIP. Its support will be soon.
 
 ## How to use it
 
@@ -22,7 +24,7 @@ linkerd easyauth [COMMAND] -n <namespace> [FLAGS]
 ```
 
 ### Supported commands
-- `authcheck`: checks for obsolete `Server` and `ServerAuthorization` resources, checks that PODs ports have `Server` resource
+- `authcheck`: checks for obsolete `Server` and policies resources like `ServerAuthorization` and `AuthorizationPolicy`, checks that PODs ports have `Server` resource
 - `list`: list of Pods that were injected by `linkerd.io/easyauth-enabled: true` annotation (more information below)
 - `authz`: fast implementation for fetch the list server authorizations for a resource (use caching)
 
@@ -40,7 +42,7 @@ Install the helm chart with injector and policies:
 ### What the helm chart provides
 - Injector that adds `linkerd.io/easyauth-enabled: true` label for all meshed pods (you can limit namespaces via helmchart)
 - `Server` in terms of Linkerd authorization policies for `linkerd-admin-port`
-- `ServerAuthorization` resources that provides basic allow policies for ingress, Linkerd itself, and monitoring
+- `AuthorizationPolicy` resources that provides basic allow policies for ingress, Linkerd itself, and monitoring
 
 ### What the helm chart does not provide
 Because the `Server` should be one per service per port, we can define the server for the linkerd proxy admin port only.
@@ -63,7 +65,7 @@ spec:
 
 ### Important Values
 #### Meshed Apps Namespaces
-Because all `ServerAuthorization` policies are Namespaced scope then we should add common policies to each namespace with our apps:
+Because all `AuthorizationPolicy` policies are Namespaced scope then we should add common policies to each namespace with our apps:
 ```
 meshedApps:
   namespaces:

--- a/charts/linkerd-easyauth/Chart.yaml
+++ b/charts/linkerd-easyauth/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.5.0"
+appVersion: "0.6.0"
 description: A Helm chart for Linkerd easyauth extension.
 name: linkerd-easyauth
-version: "0.5.0"
+version: "0.6.0"

--- a/charts/linkerd-easyauth/templates/auth-policies.yml
+++ b/charts/linkerd-easyauth/templates/auth-policies.yml
@@ -5,72 +5,87 @@ kind: Server
 metadata:
   namespace: {{ . }}
   name: linkerd-admin-port
-  labels:
-    linkerd.io/server-type: common
 spec:
   podSelector:
     matchLabels:
-      linkerd.io/easyauth: true
+      linkerd.io/easyauth: "true"
   port: linkerd-admin
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: Server
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
 metadata:
   namespace: {{ . }}
-  name: app-serving-port
-  labels:
-    linkerd.io/server-type: common
+  name: linkerd-authn
 spec:
-  podSelector:
-    matchLabels:
-      linkerd.io/easyauth: true
-  port: linkerd-admin
+  identities:
+  {{- range $.Values.policies.linkerd.namespaces }}
+    - "*.{{ . }}.serviceaccount.identity.linkerd.cluster.local"
+  {{- end }}
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: {{ . }}
   name: linkerd-admin-allow
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: linkerd-admin-port
-  client:
-    meshTLS:
-      identities:
-      {{- range $.Values.policies.linkerd.namespaces }}
-        - "*.{{ . }}.serviceaccount.identity.linkerd.cluster.local"
-      {{- end }}
----
+  requiredAuthenticationRefs:
+    - name: linkerd-authn
+      kind: MeshTLSAuthentication
+      group: policy.linkerd.io
 {{- if $.Values.policies.monitoring.enabled }}
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
+metadata:
+  namespace: {{ . }}
+  name: monitoring-authn
+spec:
+  identities:
+    - "*.{{ $.Values.policies.monitoring.namespace }}.serviceaccount.identity.linkerd.cluster.local"
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: {{ . }}
   name: linkerd-monitoring-allow
 spec:
-  server:
-    selector:
-      matchLabels:
-        linkerd.io/server-type: common
-  client:
-    meshTLS:
-      identities:
-        - "*.{{ $.Values.policies.monitoring.namespace }}.serviceaccount.identity.linkerd.cluster.local"
+  targetRef:
+    group: core
+    kind: Namespace
+    name: {{ . }}
+  requiredAuthenticationRefs:
+    - name: monitoring-authn
+      kind: MeshTLSAuthentication
+      group: policy.linkerd.io
 {{ end }}
 {{- if $.Values.policies.ingress.enabled }}
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
+metadata:
+  namespace: {{ . }}
+  name: ingress-authn
+spec:
+  identities:
+    - "*.{{ $.Values.policies.ingress.namespace }}.serviceaccount.identity.linkerd.cluster.local"
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: {{ . }}
   name: linkerd-ingress-allow
 spec:
-  server:
-    selector:
-      matchLabels:
-        linkerd.io/server-type: common
-  client:
-    meshTLS:
-      identities:
-        - "*.{{ $.Values.policies.ingress.namespace }}.serviceaccount.identity.linkerd.cluster.local"
+  targetRef:
+    group: core
+    kind: Namespace
+    name: {{ . }}
+  requiredAuthenticationRefs:
+    - name: ingress-authn
+      kind: MeshTLSAuthentication
+      group: policy.linkerd.io
 {{ end }}
 {{ end }}

--- a/charts/linkerd-easyauth/templates/easyauth-injector.yml
+++ b/charts/linkerd-easyauth/templates/easyauth-injector.yml
@@ -11,7 +11,7 @@ metadata:
   name: easyauth-injector
   namespace: {{.Values.namespace}}
 spec:
-  replicas: 1
+  replicas: {{ .Values.webhook.replicas }}
   selector:
     matchLabels:
       linkerd.io/extension: easyauth

--- a/charts/linkerd-easyauth/values.yaml
+++ b/charts/linkerd-easyauth/values.yaml
@@ -9,8 +9,11 @@ tolerations: &default_tolerations
 webhook:
   image:
     name: aatarasoff/linkerd-easyauth-webhook
-    version: 0.1.0
+    version: 0.6.0
     pullPolicy: IfNotPresent
+
+  # modify to HA mode
+  replicas: 1
 
   logLevel: info
 


### PR DESCRIPTION
Changes:

- Helm chart uses `AuthorizationPolicy` instead of `ServerAuthorization`
- `authcheck` command supports `AuthorizationPolicy` resources
